### PR TITLE
Added Capability for Tome of Battle's Warblade to use the Fighter Advanc...

### DIFF
--- a/data/35e/wizards_of_the_coast/supplement/tome_of_battle/tob_classes.lst
+++ b/data/35e/wizards_of_the_coast/supplement/tome_of_battle/tob_classes.lst
@@ -61,7 +61,12 @@ CLASS:Warblade	SPELLSTAT:WIS	BONUSSPELLSTAT:NONE	SPELLTYPE:Martial	MEMORIZE:NO	B
 1	BONUS:VAR|WarbladeReadiedManuevers|3+(CL>3)+(CL>9)+(CL>14)+(CL>19)	DEFINE:WarbladeReadiedManuevers|0
 1	BONUS:VAR|WarbladeInitiatorLVL|WarbladeLVL+(WarbladeLVL-TL/2)		DEFINE:WarbladeInitiatorLVL|0
 1	BONUS:VAR|WarbladeInitiatorManeuverLVL|(1+WarbladeInitiatorLVL)/2		DEFINE:WarbladeInitiatorManeuverLVL|0
+1	BONUS:VAR|FighterLVL|(WarbladeLVL-2)
 ###Block:
+1								ABILITY:Special Ability|AUTOMATIC|Fighter Level Advanced Feat Tracker
+1								ABILITY:Special Ability|AUTOMATIC|Weapon Specialization Qualify|!PREABILITY:1,CATEGORY=ACF,TYPE.FighterWeaponSpecialization
+1								ABILITY:Special Ability|AUTOMATIC|Greater Weapon Focus Qualify|!PREABILITY:1,CATEGORY=ACF,TYPE.FighterGreaterWeaponFocus
+1								ABILITY:Special Ability|AUTOMATIC|Greater Weapon Specialization Qualify|!PREABILITY:1,CATEGORY=ACF,TYPE.FighterGreaterWeaponSpecialization
 1								ABILITY:Warblade Class Feature|AUTOMATIC|Warblade ~ Battle Clarity|Warblade ~ Maneuvers|Warblade ~ Maneuvers Readied|Warblade ~ Stances Known|Warblade ~ Weapon and Armor Proficiency|Warblade ~ Weapon Aptitude
 2								ABILITY:Warblade Class Feature|AUTOMATIC|Warblade ~ Uncanny Dodge
 3								ABILITY:Warblade Class Feature|AUTOMATIC|Warblade ~ Battle Ardor


### PR DESCRIPTION
...ed feat tracker at two levels below warblade level,  Per 'Weapon Aptitude ability:

"You qualify for feats that usually require a minimum number of fighter levels (such as Weapon Specialization) as if you had a fighter level equal to your warblade level -2. For example, as a 6th-level warblade, you could take Weapon Specialization, since you're treated as being a 4th-level fighter for this purpose. "