### PR TITLE
added "Ranged Spells" to weapon proficiency list, needed for some Comple...

### DIFF
--- a/data/35e/wizards_of_the_coast/core/players_handbook/ph_profs_weapon.lst
+++ b/data/35e/wizards_of_the_coast/core/players_handbook/ph_profs_weapon.lst
@@ -5,6 +5,7 @@
 Grapple				TYPE:Auto.Simple.SimpleMelee
 Spells (Ray)			TYPE:Auto.Simple
 Spells (Touch)			TYPE:Auto.Simple.SimpleMelee
+Ranged Spell			TYPE:Auto.Simple.Ranged.SimpleRanged
 
 # Name of Proficiency		Weapon groups
 # Weapon Name			Type


### PR DESCRIPTION
...te Mage feats

The feats "Ranged Spell Specialization" from Complete Arcane, and "Ranged Recall" from Complete Mage both reaquire "Weapon Focus (Ranged Spell)"