### PR TITLE
Fix so Player's Handbook is not counted as Core35e booktype

### DIFF
--- a/data/35e/wizards_of_the_coast/core/players_handbook/_players_handbook.pcc
+++ b/data/35e/wizards_of_the_coast/core/players_handbook/_players_handbook.pcc
@@ -3,7 +3,7 @@ CAMPAIGN:Player's Handbook - Core Rulebook I v.3.5
 KEY:Player's Handbook v.3.5
 RANK:0
 !PRECAMPAIGN:1,BOOKTYPE=Core Rules,[Player's Handbook v.3.5]
-BOOKTYPE:Core35e|Core Rules
+BOOKTYPE:Core Rules
 GAMEMODE:Bahamut35e
 SOURCELONG:Player's Handbook
 SOURCESHORT:PH


### PR DESCRIPTION
Some of the books have something like 
"PRECAMPAIGN=2,INCLUDESBOOKTYPE=Core35e,INCLUDES=XXXX" in their pcc's.  
WIth both "_core_books.pcc" and "_players_handbook.pcc" both having this booktype, this counts as 2 passes so the book can be loaded even if the other "INCLUDES" clause fails.  Improperly loading the book without the proper prereqs can lead to other errors.

Another option would be to find all of the books with 
"PRECAMPAIGN=2,INCLUDESBOOKTYPE=Core35e,INCLUDES=XXXX" and maybe replace it with
"PRECAMPAIGN=2,BOOKTYPE=Core35e,INCLUDES=XXXX"
This works because no matter how many Core35e books there are, the BOOKTYPE clause only resolves to 1 and therefore the other clause has to be met as well.