### PR TITLE
Fix error Core Book 3.5 Tome of Magic

### DIFF
--- a/data/35e/wizards_of_the_coast/supplement/tome_of_magic/_tome_of_magic.pcc
+++ b/data/35e/wizards_of_the_coast/supplement/tome_of_magic/_tome_of_magic.pcc
@@ -24,7 +24,7 @@ LOGO:../../../../_artwork/logo_wotc.png
 ABILITY:tm_abilities.lst
 ABILITYCATEGORY:tm_abilitycategories.lst
 CLASS:tm_classes.lst
-EQUIP:tm_equip.lst
+EQUIPMENT:tm_equip.lst
 EQUIPMOD:tm_equipmods.lst
 ABILITY:tm_feats.lst
 SPELL:tm_spells.lst


### PR DESCRIPTION
EQUIP was wrong replaced with EQUIPMENT.