### PR TITLE
Adding missing Warlock Pact of the Tome Cantrips for Elemental Evil

### DIFF
--- a/data/5e/wizards_of_the_coast/supplement/elemental_evil_players_companion/eepc_abilities.lst
+++ b/data/5e/wizards_of_the_coast/supplement/elemental_evil_players_companion/eepc_abilities.lst
@@ -106,3 +106,14 @@ Gust			KEY:Wizard Cantrip ~ Gust			TYPE:Wizard Cantrip	CATEGORY:Internal	SPELLKN
 Mold Earth		KEY:Wizard Cantrip ~ Mold Earth		TYPE:Wizard Cantrip	CATEGORY:Internal	SPELLKNOWN:CLASS|Wizard=0|Mold Earth	SPELLS:Wizard Cantrip|TIMES=ATWILL|CASTERLEVEL=1|Mold Earth,Spell_DC_Wizard
 Shape Water		KEY:Wizard Cantrip ~ Shape Water		TYPE:Wizard Cantrip	CATEGORY:Internal	SPELLKNOWN:CLASS|Wizard=0|Shape Water	SPELLS:Wizard Cantrip|TIMES=ATWILL|CASTERLEVEL=1|Shape Water,Spell_DC_Wizard
 Thunderclap		KEY:Wizard Cantrip ~ Thunderclap		TYPE:Wizard Cantrip	CATEGORY:Internal	SPELLKNOWN:CLASS|Wizard=0|Thunderclap	SPELLS:Wizard Cantrip|TIMES=ATWILL|CASTERLEVEL=1|Thunderclap,Spell_DC_Wizard
+
+###Block - Warlock Pact of the Tome Cantrip
+Thunderclap	KEY:Warlock Pact of the Tome Cantrip ~ Thunderclap	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Thunderclap
+Create Bonfire	KEY:Warlock Pact of the Tome Cantrip ~ Create Bonfire	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Create Bonfire
+Control Flames	KEY:Warlock Pact of the Tome Cantrip ~ Control Flames	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Control Flames
+Frostbite	KEY:Warlock Pact of the Tome Cantrip ~ Frostbite	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Frostbite
+Gust		KEY:Warlock Pact of the Tome Cantrip ~ Gust		CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Gust
+Magic Stone	KEY:Warlock Pact of the Tome Cantrip ~ Magic Stone	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Magic Stone
+Mold Earth	KEY:Warlock Pact of the Tome Cantrip ~ Mold Earth	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Mold Earth
+Shape Water	KEY:Warlock Pact of the Tome Cantrip ~ Shape Water	CATEGORY:Internal	TYPE:WarlockPactoftheTomeCantrips	SPELLKNOWN:CLASS|Warlock=0|Shape Water
+


### PR DESCRIPTION
Warlock Pact of the Tome is not able to use Elemental Evil Cantrips.
Added missing Spells to it.