### PR TITLE
CV_DukarClassReqFix

### DIFF
--- a/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/champions_of_valor/cv_classes.lst
+++ b/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/champions_of_valor/cv_classes.lst
@@ -43,7 +43,8 @@ SUBSTITUTIONLEVEL:8	ABILITY:Special Ability|AUTOMATIC|Darksong Knight ~ Combat D
 
 # Class Name
 CLASS:Wizard.MOD
-SUBSTITUTIONCLASS:Dukar	ADD:CLASSSKILLS|Swim	PRETEXT:The character must undergo a ritual and have living coral implanted under his skin.	SOURCEPAGE:38
+SUBSTITUTIONCLASS:Dukar	PREITEM:1,Dukar Hand Coral	PRETEXT:The character must undergo a ritual and have living coral implanted under his skin.	SOURCEPAGE:38
+SUBSTITUTIONCLASS:Dukar	ADD:CLASSSKILLS|Swim	
 SUBSTITUTIONLEVEL:5								ABILITY:Special Ability|AUTOMATIC|Dukar ~ Bonus Spells 1|Dukar ~ Coral Claw	ADD:SPELLCASTER|Wizard
 SUBSTITUTIONLEVEL:10	BONUS:ABILITYPOOL|CoralPowerAbility|1	ABILITY:Special Ability|AUTOMATIC|Dukar ~ Bonus Spells 2|Dukar ~ Coral Power	ADD:SPELLCASTER|Wizard
 SUBSTITUTIONLEVEL:15	BONUS:ABILITYPOOL|CoralPowerAbility|1	ABILITY:Special Ability|AUTOMATIC|Dukar ~ Bonus Spells 3				ADD:SPELLCASTER|Wizard


### PR DESCRIPTION
The Dukar substitution class previously only cited it pre-req as a
PRETEXT instead of the PREITEM it should have been.