### PR TITLE
MissingDeadLanguages

### DIFF
--- a/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/players_guide_to_faerun/pg_languages.lst
+++ b/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/players_guide_to_faerun/pg_languages.lst
@@ -30,3 +30,10 @@ Untheric		TYPE:Spoken.Written.Read.RegionalDialect
 Undercommon	TYPE:Spoken.RegionalDialect
 
 Kir-lanan		TYPE:Spoken.Written.Read.RegionalDialect
+
+
+# dead languages
+Aragrakh		TYPE:Spoken.Written.Read	DESC:A dead language of Faerun, used by old dragons, using the Draconic alphabet.
+Hulgorkyn		TYPE:Spoken.Written.Read	DESC:A dead language of Faerun, an archaic orc tongue, using the Dethek alphabet.
+Roushoum		TYPE:Spoken.Written.Read	DESC:A dead language of Faerun, a precursor to Tuigan, using the Imaskari alphabet.
+Seldruin		TYPE:Spoken.Written.Read	DESC:A dead language of Faerun, the language of Elven high magic, using the Hamarfae alphabet.


### PR DESCRIPTION
Added the missing dead languages to the Player's Guide. Much of this is
superfluous except that the missing Roushoum language is a pre-req for
the Raumathari Battlemage class.