### PR TITLE
Update on cw_classes for tattoed monk

### DIFF
--- a/data/35e/wizards_of_the_coast/supplement/complete_warrior/cw_classes.lst
+++ b/data/35e/wizards_of_the_coast/supplement/complete_warrior/cw_classes.lst
@@ -861,7 +861,7 @@ CLASS:Tattooed Monk	STARTSKILLPTS:4	CSKILL:Balance|Climb|Concentration|TYPE=Craf
 ###Block:
 1	BONUS:ABILITYPOOL|Tatoo Power|(CL+1)/2
 ###Block:
-1	BONUS:VAR|MonkACLVL,MonkMoveLVL|CL
+1	BONUS:VAR|MonkACLVL,MonkMoveLVL,MonkUnarmedDamageLVL|CL
 1	BONUS:VAR|TatooedMonkTatooPowerLVL|CL
 ###Block:
 11	PREPCLEVEL:MIN=20
@@ -920,4 +920,3 @@ CLASS:Warshaper	STARTSKILLPTS:2	CSKILL:Balance|Climb|Concentration|TYPE=Craft|Di
 5	ABILITY:Warshaper Class Feature|AUTOMATIC|Warshaper ~ Flashmorph/Multimorph
 ###Block
 5	BONUS:ABILITYPOOL|Warshaper Morph|1
-


### PR DESCRIPTION
Tattoed monk levels did not stack with standard monk for unarmed damage, I fixed it. There is mention of the UDAM a couple of lines above it, but it didn't seem to work, I kept it there because i don't know if it would mess up somehting else.