### PR TITLE
AgeSet, Wands, and Red dragon diplomacy

### DIFF
--- a/data/35e/wizards_of_the_coast/core/monster_manual/mm_skills.lst
+++ b/data/35e/wizards_of_the_coast/core/monster_manual/mm_skills.lst
@@ -6,6 +6,7 @@ Control Shape		KEYSTAT:WIS	USEUNTRAINED:YES			TYPE:Wisdom.Standard									PRETE
 
 
 # Conditional
-Diplomacy (Red Dragons)	KEYSTAT:CHA	USEUNTRAINED:YES	CLASSES:ALL	TYPE:SkillUse		VISIBLE:EXPORT	PRERULE:1,DISPLAYSKILLUSE							PREVARNEQ:var("SKILL.Diplomacy (Red Dragons).MISC"),var("SKILL.Diplomacy.MISC")	SOURCEPAGE:p.128
+# This should be a SITUATIONAL skill
+Diplomacy (Red Dragons)	KEYSTAT:CHA	USEUNTRAINED:YES	CLASSES:ALL	TYPE:SkillUse		VISIBLE:EXPORT	PRERULE:1,DISPLAYSKILLUSE							PREVARNEQ:var("SKILL.Diplomacy (Red Dragons).MISC"),var("SKILL.Diplomacy.MISC")	SOURCEPAGE:p.128	PREABILITY:1,CATEGORY=Special Ability,Githyanki ~ Red Dragon Pact
 
 Diplomacy.MOD																																												BONUS:SKILL|Diplomacy (Red Dragons)|SKILL.Diplomacy.MISC	BONUS:SKILLRANK|Diplomacy (Red Dragons)|SKILLRANK=Diplomacy|TYPE=SkillGranted|PRERULE:1,DISPLAYSKILLUSE


### PR DESCRIPTION
3 separate branches, 3 seperate small changes.

AGESET - fixed the xph bio_settings typo
Wands - added some more wand spell descriptions
Red Dragon Diplomacy - modified a skill (that really should be a situational skill) so it only appears for the race that actually gets the bonus.