### PR TITLE
Fix Monk Flurry of Blows

### DIFF
--- a/data/35e/wizards_of_the_coast/core/players_handbook/ph_abilities.lst
+++ b/data/35e/wizards_of_the_coast/core/players_handbook/ph_abilities.lst
@@ -622,7 +622,7 @@ Monk Unarmed Damage LVL 20 (Colossal)	CATEGORY:Internal		UDAM:12d8		UMULT:2			BO
 
 ###Block - New Flurry of Blows system
 CATEGORY=Special Ability|Monk ~ Flurry of Blows.MOD	DEFINE:FlurryLVL|0	BONUS:VAR|FlurryLVL|MonkLVL	DEFINE:GreaterFlurry|0	BONUS:VAR|GreaterFlurry|(FlurryLVL>=11)|!PREABILITY:1,CATEGORY=ACF,TYPE.MonkGreaterFlurry	
-CATEGORY=Special Ability|Monk ~ Flurry of Blows.MOD	DEFINE:FlurryAttacks|0	BONUS:VAR|FlurryAttacks|1+(FlurryLVL>=8)+(GreaterFlurry>=1)+(FlurryLVL>=15)	
+CATEGORY=Special Ability|Monk ~ Flurry of Blows.MOD	DEFINE:FlurryAttacks|0	BONUS:VAR|FlurryAttacks|1+(GreaterFlurry>=1)+(FlurryLVL>=15)	
 CATEGORY=Special Ability|Monk ~ Flurry of Blows.MOD	DEFINE:FAB|0	BONUS:VAR|FAB|-2+(FlurryLVL>=5)+(FlurryLVL>=9)
 CATEGORY=Special Ability|Monk ~ Flurry of Blows.MOD	DEFINE:FAB_1|0	BONUS:VAR|FAB_1|FAB
 CATEGORY=Special Ability|Monk ~ Flurry of Blows.MOD	DEFINE:FAB_2|0	BONUS:VAR|FAB_2|FAB


### PR DESCRIPTION
At level 8 the Monk was getting an additional Flurry of Blows (4 total), when it should have had 3 total.

Please let me know if I did something incorrectly!