### PR TITLE
Fixed Remove Familiar (Wizard) ACF

### DIFF
--- a/data/35e/wizards_of_the_coast/core/players_handbook/ph_abilities.lst
+++ b/data/35e/wizards_of_the_coast/core/players_handbook/ph_abilities.lst
@@ -1043,7 +1043,7 @@ Mind Will Save	OUTPUTNAME:+2 on Will saves vs. Enchantment spells and effects	CA
 ###Block: ACF - Alternate Class Features
 # Ability Name				Unique Key					Category of Ability		Type											Visible	Define												Description																	Choose											Ability																																																																								Modify VAR					Cost		Source Page					Temporary effect description												Temporary Bonus
 Remove Scribe Scroll									CATEGORY:ACF			TYPE:WizardScribeScroll.ACF																																																																																																																																			COST:0
-Remove Familiar (Wizard)								CATEGORY:ACF			TYPE:WizardFamiliar.ACF																																																																																																																																				COST:0
+Remove Familiar (Wizard)								CATEGORY:ACF			TYPE:WizardSummonFamiliar.ACF																																																																																																																																				COST:0
 Remove Familiar (Sorcerer)								CATEGORY:ACF			TYPE:SorcererFamiliar.ACF																																																																																																																																			COST:0
 
 


### PR DESCRIPTION
The ACF was using the wrong TYPE and therefore didn't remove the Familiar class feature.

In the long run it might be worth it to check for consistency between ACF type names in classes that gain familiars.
E.g. Sorcerers currently use TYPE.SorcererFamiliar ([line](https://github.com/BahamutDragon/pcgen/blob/master/data/35e/wizards_of_the_coast/core/players_handbook/ph_classes.lst#L325)), while Wizards use TYPE.WizardSummonFamiliar ([line](https://github.com/BahamutDragon/pcgen/blob/master/data/35e/wizards_of_the_coast/core/players_handbook/ph_classes.lst#L377)) to check for ACFs.

