### PR TITLE
Fixed incorrect SPELLS on scrolls

### DIFF
--- a/data/35e/wizards_of_the_coast/core/dungeon_masters_guide/dmg_equip.lst
+++ b/data/35e/wizards_of_the_coast/core/dungeon_masters_guide/dmg_equip.lst
@@ -714,7 +714,7 @@ Scroll (Chill Touch)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Chill To
 Scroll (Color Spray)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Color Spray	TYPE:Magic.Scroll.Arcane.Consumable	COST:25	WT:0.01	SPROP:15' Cone stuns creatures based on HD (5+ stunned for 1 round, 4- also blind & stunned for 1d4 rounds, 2- also unconscious for 2d4 rounds. Will DC 11 negates(PH 210)	SOURCEPAGE:p.237
 Scroll (Color Spray/Wizard/2nd)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=2|Color Spray	TYPE:Magic.Scroll.Arcane.Consumable	COST:50	WT:0.01	SPROP:15' Cone stuns creatures based on HD (5+ stunned for 1 round, 4- also blind & stunned for 1d4 rounds, 2- also unconscious for 2d4 rounds. Will DC 11 negates(PH 210)	SOURCEPAGE:p.237
 Scroll (Comprehend Languages/Arcane)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Comprehend Languages	OUTPUTNAME:Scroll (Comprehend Languages)		TYPE:Magic.Scroll.Arcane.Consumable	COST:25	WT:0.01	SOURCEPAGE:p.237
-Scroll (Confusion/Lesser)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Confusion, Lesser	OUTPUTNAME:Scroll (Confusion, Lesser)		TYPE:Magic.Scroll.Arcane.Consumable	COST:50	WT:0.01	SOURCEPAGE:p.237
+Scroll (Confusion/Lesser)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Confusion (Lesser)	OUTPUTNAME:Scroll (Confusion, Lesser)		TYPE:Magic.Scroll.Arcane.Consumable	COST:50	WT:0.01	SOURCEPAGE:p.237
 Scroll (Cure Light Wounds/Arcane)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Cure Light Wounds	OUTPUTNAME:Scroll (Cure Light Wounds)		TYPE:Magic.Scroll.Arcane.Consumable	COST:50	WT:0.01	SOURCEPAGE:p.237	SPROP:Cures 1d8+1 damage (PH P.215)
 Scroll (Detect Secret Doors)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Detect Secret Doors	TYPE:Magic.Scroll.Arcane.Consumable	COST:25	WT:0.01	SOURCEPAGE:p.237
 Scroll (Detect Undead/Arcane)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=1|Detect Undead	OUTPUTNAME:Scroll (Detect Undead)			TYPE:Magic.Scroll.Arcane.Consumable	COST:25	WT:0.01	SOURCEPAGE:p.237
@@ -849,7 +849,7 @@ Scroll (Magic Circle against Chaos/Arcane)							SPELLS:Magic Item|TIMES=1|CASTE
 Scroll (Magic Circle against Evil/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Circle against Evil	OUTPUTNAME:Scroll (Magic Circle against Evil)	TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Magic Circle against Good/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Circle against Good	OUTPUTNAME:Scroll (Magic Circle against Good)	TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Magic Circle against Law/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Circle against Law	OUTPUTNAME:Scroll (Magic Circle against Law)	TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
-Scroll (Magic Weapon/Greater/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Weapon, Greater	OUTPUTNAME:Scroll (Magic Weapon, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
+Scroll (Magic Weapon/Greater/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Weapon (Greater)	OUTPUTNAME:Scroll (Magic Weapon, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Major Image)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Major Image	TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Nondetection/Arcane)										SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Nondetection	OUTPUTNAME:Scroll (Nondetection)			TYPE:Magic.Scroll.Arcane.Consumable	SPROP:Difficult to detect by divination spells for 5 hours (PH P.245)	COST:425	WT:0.01	SOURCEPAGE:p.237
 Scroll (Phantom Steed)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Phantom Steed	TYPE:Magic.Scroll.Arcane.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
@@ -885,19 +885,18 @@ Scroll (Detect Scrying)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7
 Scroll (Dimension Door)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Dimension Door	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dimensional Anchor/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Dimensional Anchor	OUTPUTNAME:Scroll (Dimensional Anchor)			TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Enervation)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Enervation	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
-Scroll (Enlarge Person/Mass)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Enlarge Person, Mass	OUTPUTNAME:Scroll (Enlarge Person, Mass)			TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
+Scroll (Enlarge Person/Mass)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Enlarge Person (Mass)	OUTPUTNAME:Scroll (Enlarge Person, Mass)			TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Black Tentacles)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Black Tentacles	OUTPUTNAME:Scroll (Evard's Black Tentacles)		TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Fear)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Fear	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Fire Shield)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Fire Shield	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Fire Trap/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Fire Trap	OUTPUTNAME:Scroll (Fire Trap)					TYPE:Magic.Scroll.Arcane.Consumable	COST:725	WT:0.01	SOURCEPAGE:p.237
 Scroll (Freedom of Movement/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Freedom of Movement	OUTPUTNAME:Scroll (Freedom of Movement)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1000	WT:0.01	SOURCEPAGE:p.237
-#SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Geas, Lesser
-Scroll (Geas/Lesser)									OUTPUTNAME:Scroll (Geas, Lesser)				TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
-Scroll (Globe of Invulnerability/Lesser)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Globe of Invulnerability, Lesser	OUTPUTNAME:Scroll (Globe of Invulnerability, Lesser)	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
+Scroll (Geas/Lesser)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Geas (Lesser)   OUTPUTNAME:Scroll (Geas, Lesser)				TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
+Scroll (Globe of Invulnerability/Lesser)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Globe of Invulnerability (Lesser)	OUTPUTNAME:Scroll (Globe of Invulnerability, Lesser)	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Hallucinatory Terrain)																SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Hallucinatory Terrain	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Ice Storm/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Ice Storm	OUTPUTNAME:Scroll (Ice Storm)					TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Illusory Wall)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Illusory Wall	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
-Scroll (Invisibility/Greater)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Invisibility, Greater	OUTPUTNAME:Scroll (Invisibility, Greater)			TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
+Scroll (Invisibility/Greater)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Invisibility (Greater)	OUTPUTNAME:Scroll (Invisibility, Greater)			TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Secure Shelter)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Secure Shelter	OUTPUTNAME:Scroll (Leomund's Secure Shelter)		TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Locate Creature)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Locate Creature	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Minor Creation)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Minor Creation	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
@@ -908,7 +907,7 @@ Scroll (Phantasmal Killer)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL
 Scroll (Polymorph)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Polymorph	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Rainbow Pattern)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Rainbow Pattern	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mnemonic Enhancer)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Mnemonic Enhancer	OUTPUTNAME:Scroll (Rary's Mnemonic Enhancer)		TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
-Scroll (Reduce Person/Mass)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Reduce Person, Mass	OUTPUTNAME:Scroll (Reduce Person, Mass)			SPROP:(PH P269)Humanoid target within 45' is halved in height/weight/width and weight is reduced to 1/8th. Size category is reduced by 1, the target gains +2 size bonus to dex, -2 Str and +1 bonus to attack and AC. Lasts 7 minutes	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
+Scroll (Reduce Person/Mass)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Reduce Person (Mass)	OUTPUTNAME:Scroll (Reduce Person, Mass)			SPROP:(PH P269)Humanoid target within 45' is halved in height/weight/width and weight is reduced to 1/8th. Size category is reduced by 1, the target gains +2 size bonus to dex, -2 Str and +1 bonus to attack and AC. Lasts 7 minutes	TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Remove Curse/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Remove Curse	OUTPUTNAME:Scroll (Remove Curse)				TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Repel Vermin/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Repel Vermin	OUTPUTNAME:Scroll (Repel Vermin)				TYPE:Magic.Scroll.Arcane.Consumable	COST:1000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Scrying/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Scrying	OUTPUTNAME:Scroll (Scrying)					TYPE:Magic.Scroll.Arcane.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
@@ -933,9 +932,9 @@ Scroll (Break Enchantment/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9
 Scroll (Cloudkill)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Cloudkill	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Cone of Cold)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Cone of Cold	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Contact Other Plane)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Contact Other Plane	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cure Light Wounds/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Cure Light Wounds, Mass	OUTPUTNAME:Scroll (Cure Light Wounds, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1625	WT:0.01	SOURCEPAGE:p.237	SPROP:Cures 1d8 +9 damage (PH P.216)
+Scroll (Cure Light Wounds/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Cure Light Wounds (Mass)	OUTPUTNAME:Scroll (Cure Light Wounds, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1625	WT:0.01	SOURCEPAGE:p.237	SPROP:Cures 1d8 +9 damage (PH P.216)
 Scroll (Dismissal/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dismissal	OUTPUTNAME:Scroll (Dismissal)					TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
-Scroll (Dispel Magic/Greater/Arcane/Lvl 5)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dispel Magic, Greater	OUTPUTNAME:Scroll (Dispel Magic, Greater/Arcane 5th)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1625	WT:0.01	SOURCEPAGE:p.237
+Scroll (Dispel Magic/Greater/Arcane/Lvl 5)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dispel Magic (Greater)	OUTPUTNAME:Scroll (Dispel Magic, Greater/Arcane 5th)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1625	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dominate Person)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dominate Person	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dream)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dream	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Fabricate)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Fabricate	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
@@ -954,7 +953,7 @@ Scroll (Overland Flight)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=
 Scroll (Passwall)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Passwall	EQMOD:SPL_CHRG|SPELLNAME[Passwall]SPELLLEVEL[5]CASTERLEVEL[9]	SPROP:Create a 5' by 8' opening 25' deep through wood or stone (PH 259)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Permanency)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Permanency	TYPE:Magic.Scroll.Arcane.Consumable	COST:10125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Persistent Image)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Persistent Image	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
-Scroll (Planar Binding/Lesser)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Planar Binding, Lesser	OUTPUTNAME:Scroll (Planar Binding, Lesser)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
+Scroll (Planar Binding/Lesser)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Planar Binding (Lesser)	OUTPUTNAME:Scroll (Planar Binding, Lesser)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Prying Eyes)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Prying Eyes	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Telepathic Bond)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Telepathic Bond	OUTPUTNAME:Scroll (Rary's Telepathic Bond)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Seeming)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Seeming	TYPE:Magic.Scroll.Arcane.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
@@ -978,41 +977,41 @@ Scroll (Acid Fog)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Aci
 Scroll (Analyze Dweomer)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Analyze Dweomer	KEY:Scroll (Analayze Dweomer)									TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Animate Objects/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Animate Objects	OUTPUTNAME:Scroll (Animate Objects)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2400	WT:0.01	SOURCEPAGE:p.237
 Scroll (Antimagic Field/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Antimagic Field	OUTPUTNAME:Scroll (Antimagic Field)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Bear's Endurance/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bear's Endurance, Mass	OUTPUTNAME:Scroll (Bear's Endurance, Mass)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Bear's Endurance/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bear's Endurance (Mass)	OUTPUTNAME:Scroll (Bear's Endurance, Mass)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Forceful Hand)										SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Forceful Hand	OUTPUTNAME:Scroll (Bigby's Forceful Hand)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Bull's Strength/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bull's Strength, Mass	OUTPUTNAME:Scroll (Bull's Strength, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cat's Grace/Mass/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cat's Grace, Mass	OUTPUTNAME:Scroll (Cat's Grace, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Bull's Strength/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bull's Strength (Mass)	OUTPUTNAME:Scroll (Bull's Strength, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cat's Grace/Mass/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cat's Grace (Mass)	OUTPUTNAME:Scroll (Cat's Grace, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Chain Lightning)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Chain Lightning	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Circle of Death)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Circle of Death	TYPE:Magic.Scroll.Arcane.Consumable	COST:2150	WT:0.01	SOURCEPAGE:p.237
 Scroll (Contingency)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Contingency	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Control Water/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Control Water	OUTPUTNAME:Scroll (Control Water)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Create Undead/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Create Undead	OUTPUTNAME:Scroll (Create Undead)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2350	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cure Moderate Wounds/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cure Moderate Wounds, Mass	OUTPUTNAME:Scroll (Cure Moderate Wounds, Mass)	SPROP:Cures 2d8 +11 damage (PH P.216)	TYPE:Magic.Scroll.Arcane.Consumable	COST:2400	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cure Moderate Wounds/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cure Moderate Wounds (Mass)	OUTPUTNAME:Scroll (Cure Moderate Wounds, Mass)	SPROP:Cures 2d8 +11 damage (PH P.216)	TYPE:Magic.Scroll.Arcane.Consumable	COST:2400	WT:0.01	SOURCEPAGE:p.237
 Scroll (Disintegrate)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Disintegrate	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Dispel Magic/Greater/Arcane/Lvl 6)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Dispel Magic, Greater	OUTPUTNAME:Scroll (Dispel Magic, Greater/Arcane 6th)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Eagle's Splendor/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Eagle's Splendor, Mass	OUTPUTNAME:Scroll (Eagle's Splendor, Mass)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Dispel Magic/Greater/Arcane/Lvl 6)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Dispel Magic (Greater)	OUTPUTNAME:Scroll (Dispel Magic, Greater/Arcane 6th)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Eagle's Splendor/Mass/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Eagle's Splendor (Mass)	OUTPUTNAME:Scroll (Eagle's Splendor, Mass)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Eyebite)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Eyebite	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Find the Path/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Find the Path	OUTPUTNAME:Scroll (Find the Path)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2400	WT:0.01	SOURCEPAGE:p.237
 Scroll (Flesh to Stone)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Flesh to Stone	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Fox's Cunning/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Fox's Cunning, Mass	OUTPUTNAME:Scroll (Fox's Cunning, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Fox's Cunning/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Fox's Cunning (Mass)	OUTPUTNAME:Scroll (Fox's Cunning, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Geas/Quest/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Geas/Quest	OUTPUTNAME:Scroll (Geas, Quest)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Globe of Invulnerability)																SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Globe of Invulnerability	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Guards and Wards)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Guards and Wards	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Heroes' Feast/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Heroes' Feast	OUTPUTNAME:Scroll (Heroes' Feast)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2400	WT:0.01	SOURCEPAGE:p.237
-Scroll (Heroism/Greater)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Heroism, Greater	OUTPUTNAME:Scroll (Heroism, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Heroism/Greater)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Heroism (Greater)	OUTPUTNAME:Scroll (Heroism, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Legend Lore)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Legend Lore	TYPE:Magic.Scroll.Arcane.Consumable	COST:1900	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mislead)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Mislead	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mage's Lucubration)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Mage's Lucubration	OUTPUTNAME:Scroll (Mordenkainen's Lucubration)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Move Earth/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Move Earth	OUTPUTNAME:Scroll (Move Earth)			TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Freezing Sphere)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Freezing Sphere	OUTPUTNAME:Scroll (Otiluke's Freezing Sphere)	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Owl's Wisdom/Mass/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Owl's Wisdom, Mass	OUTPUTNAME:Scroll (Owl's Wisdom, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Owl's Wisdom/Mass/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Owl's Wisdom (Mass)	OUTPUTNAME:Scroll (Owl's Wisdom, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Permanent Image)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Permanent Image	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Planar Binding)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Planar Binding	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Programmed Image)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Programmed Image	TYPE:Magic.Scroll.Arcane.Consumable	COST:1675	WT:0.01	SOURCEPAGE:p.237
 Scroll (Repulsion/Arcane)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Repulsion	OUTPUTNAME:Scroll (Repulsion)				TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Shadow Walk)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Shadow Walk	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Stone to Flesh)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Stone to Flesh	TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Suggestion/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Suggestion, Mass	OUTPUTNAME:Scroll (Suggestion, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Suggestion/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Suggestion (Mass)	OUTPUTNAME:Scroll (Suggestion, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Summon Monster VI/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Summon Monster VI	OUTPUTNAME:Scroll (Summon Monster VI)		TYPE:Magic.Scroll.Arcane.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Symbol of Fear/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Symbol of Fear	OUTPUTNAME:Scroll (Symbol of Fear)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Symbol of Persuasion/Arcane)							SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Symbol of Persuasion	OUTPUTNAME:Scroll (Symbol of Persuasion)		TYPE:Magic.Scroll.Arcane.Consumable	COST:6650	WT:0.01	SOURCEPAGE:p.237
@@ -1025,7 +1024,7 @@ Scroll (Wall of Iron)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|
 
 ###Block: 7th-level Arcane Scrolls
 # Equipment Name				Unique Key						Output Name									Type						Cost		Weight	Source Page
-Scroll (Arcane Sight/Greater)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Arcane Sight, Greater	OUTPUTNAME:Scroll (Arcane Sight, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Arcane Sight/Greater)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Arcane Sight (Greater)	OUTPUTNAME:Scroll (Arcane Sight, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Banishment/Arcane)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Banishment	KEY:Scroll (Banishement/Arcane)		OUTPUTNAME:Scroll (Banishment)					TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Grasping Hand)										SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Grasping Hand	OUTPUTNAME:Scroll (Bigby's Grasping Hand)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Control Undead)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Control Undead	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
@@ -1035,9 +1034,9 @@ Scroll (Instant Summons)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Instan
 Scroll (Ethereal Jaunt/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Ethereal Jaunt	OUTPUTNAME:Scroll (Ethereal Jaunt)					TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Finger of Death/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Finger of Death	OUTPUTNAME:Scroll (Finger of Death)					TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Forcecage)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Forcecage	TYPE:Magic.Scroll.Arcane.Consumable	COST:23775	WT:0.01	SOURCEPAGE:p.237
-Scroll (Hold Person/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Hold Person, Mass	OUTPUTNAME:Scroll (Hold Person, Mass)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Hold Person/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Hold Person (Mass)	OUTPUTNAME:Scroll (Hold Person, Mass)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Insanity)																					SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Insanity	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Invisibility/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Invisibility, Mass	OUTPUTNAME:Scroll (Invisibility, Mass)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Invisibility/Mass)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Invisibility (Mass)	OUTPUTNAME:Scroll (Invisibility, Mass)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Limited Wish)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Limited Wish	TYPE:Magic.Scroll.Arcane.Consumable	COST:3775	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mage's Magnificent Mansion)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Mage's Magnificent Mansion	OUTPUTNAME:Scroll (Mordenkainen's Magnificent Mansion)	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mage's Sword)										SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Mage's Sword	OUTPUTNAME:Scroll (Mordenkainen's Sword)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
@@ -1047,9 +1046,9 @@ Scroll (Power Word Blind)																			SPELLS:Magic Item|TIMES=1|CASTERLEVE
 Scroll (Prismatic Spray)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Prismatic Spray	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Project Image)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Project Image	TYPE:Magic.Scroll.Arcane.Consumable	COST:2280	WT:0.01	SOURCEPAGE:p.237
 Scroll (Reverse Gravity/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Reverse Gravity	OUTPUTNAME:Scroll (Reverse Gravity)					TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Scrying/Greater/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Scrying, Greater	OUTPUTNAME:Scroll (Scrying, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Scrying/Greater/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Scrying (Greater)	OUTPUTNAME:Scroll (Scrying, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Sequester)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Sequester	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Shadow Conjuration/Greater)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Shadow Conjuration, Greater	OUTPUTNAME:Scroll (Shadow Conjuration, Greater)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Shadow Conjuration/Greater)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Shadow Conjuration (Greater)	OUTPUTNAME:Scroll (Shadow Conjuration, Greater)			TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Simulacrum)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Simulacrum	TYPE:Magic.Scroll.Arcane.Consumable	COST:7275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Spell Turning)																				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Spell Turning	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Statue)																					SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Statue	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
@@ -1057,7 +1056,7 @@ Scroll (Summon Monster VII/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=
 Scroll (Symbol of Stunning/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Symbol of Stunning	OUTPUTNAME:Scroll (Symbol of Stunning)				TYPE:Magic.Scroll.Arcane.Consumable	COST:7275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Symbol of Weakness/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Symbol of Weakness	OUTPUTNAME:Scroll (Symbol of Weakness)				TYPE:Magic.Scroll.Arcane.Consumable	COST:7275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Teleport Object)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Teleport Object	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Teleport/Greater)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Teleport, Greater	OUTPUTNAME:Scroll (Teleport, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Teleport/Greater)									SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Teleport (Greater)	OUTPUTNAME:Scroll (Teleport, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Vision)																					SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Vision	TYPE:Magic.Scroll.Arcane.Consumable	COST:2775	WT:0.01	SOURCEPAGE:p.237
 Scroll (Waves of Exhaustion)																			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Waves of Exhaustion	TYPE:Magic.Scroll.Arcane.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 
@@ -1066,7 +1065,7 @@ Scroll (Waves of Exhaustion)																			SPELLS:Magic Item|TIMES=1|CASTERL
 Scroll (Antipathy/Arcane)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Antipathy	OUTPUTNAME:Scroll (Antipathy)					TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Clenched Fist)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Clenched Fist	OUTPUTNAME:Scroll (Bigby's Clenched Fist)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Binding)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Binding	TYPE:Magic.Scroll.Arcane.Consumable	COST:8500	WT:0.01	SOURCEPAGE:p.237
-Scroll (Charm Monster/Mass)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Charm Monster, Mass	OUTPUTNAME:Scroll (Charm Monster, Mass)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Charm Monster/Mass)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Charm Monster (Mass)	OUTPUTNAME:Scroll (Charm Monster, Mass)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Clone)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Clone	TYPE:Magic.Scroll.Arcane.Consumable	COST:4000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Create Greater Undead/Arcane)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Create Greater Undead	OUTPUTNAME:Scroll (Create Greater Undead)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Demand)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Demand	TYPE:Magic.Scroll.Arcane.Consumable	COST:3600	WT:0.01	SOURCEPAGE:p.237
@@ -1080,17 +1079,17 @@ Scroll (Mind Blank)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Mind Bl
 Scroll (Moment of Prescience)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Moment of Prescience	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Telekinetic Sphere)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Telekinetic Sphere	OUTPUTNAME:Scroll (Otiluke's Telekinetic Sphere)	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Irresistible Dance)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Irresistible Dance	OUTPUTNAME:Scroll (Otto's Irresistible Dance)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
-Scroll (Planar Binding/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Planar Binding, Greater	OUTPUTNAME:Scroll (Planar Binding, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Planar Binding/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Planar Binding (Greater)	OUTPUTNAME:Scroll (Planar Binding, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Polar Ray)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Polar Ray	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Polymorph Any Object)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Polymorph Any Object	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237	SPROP:Change one object or creature into another, duration depends on how radical a change is made. Gain physical stats of new form(PH p.263)
 Scroll (Power Word Stun)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Power Word Stun	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Prismatic Wall)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Prismatic Wall	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Protection from Spells)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Protection from Spells	TYPE:Magic.Scroll.Arcane.Consumable	COST:3500	WT:0.01	SOURCEPAGE:p.237
-Scroll (Prying Eyes/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Prying Eyes, Greater	OUTPUTNAME:Scroll (Prying Eyes, Greater)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Prying Eyes/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Prying Eyes (Greater)	OUTPUTNAME:Scroll (Prying Eyes, Greater)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Scintillating Pattern)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Scintillating Pattern	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Screen)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Screen	TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
-Scroll (Shadow Evocation/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Shadow Evocation, Greater	OUTPUTNAME:Scroll (Shadow Evocation, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
-Scroll (Shout/Greater)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Shout, Greater	OUTPUTNAME:Scroll (Shout, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Shadow Evocation/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Shadow Evocation (Greater)	OUTPUTNAME:Scroll (Shadow Evocation, Greater)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Shout/Greater)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Shout (Greater)	OUTPUTNAME:Scroll (Shout, Greater)				TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Summon Monster VIII/Arcane)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Summon Monster VIII	OUTPUTNAME:Scroll (Summon Monster VIII)			TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Sunburst/Arcane)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Sunburst	OUTPUTNAME:Scroll (Sunburst)					TYPE:Magic.Scroll.Arcane.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Symbol of Death/Arcane)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Symbol of Death	OUTPUTNAME:Scroll (Symbol of Death)				TYPE:Magic.Scroll.Arcane.Consumable	COST:8000	WT:0.01	SOURCEPAGE:p.237
@@ -1109,7 +1108,7 @@ Scroll (Etherealness/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Eth
 Scroll (Foresight/Arcane)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Foresight	OUTPUTNAME:Scroll (Foresight)				TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Freedom)																		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Freedom	TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Gate/Arcane)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Gate	KEY:Scroll (Gate)				OUTPUTNAME:Scroll (Gate)				TYPE:Magic.Scroll.Arcane.Consumable	COST:8825	WT:0.01	SOURCEPAGE:p.237
-Scroll (Hold Monster/Mass)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Hold Monster, Mass	OUTPUTNAME:Scroll (Hold Monster, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
+Scroll (Hold Monster/Mass)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Hold Monster (Mass)	OUTPUTNAME:Scroll (Hold Monster, Mass)		TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Imprisonment)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Imprisonment	TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Meteor Swarm)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Meteor Swarm	TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mage's Disjunction)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Mage's Disjunction	OUTPUTNAME:Scroll (Mordenkainen's Disjunction)	TYPE:Magic.Scroll.Arcane.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
@@ -1232,7 +1231,7 @@ Scroll (Owl's Wisdom/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Owl's Wis
 Scroll (Reduce Animal)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Reduce Animal	TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
 Scroll (Remove Paralysis)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Remove Paralysis	TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
 Scroll (Resist Energy/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Resist Energy	OUTPUTNAME:Scroll (Resist Energy)			TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
-Scroll (Restoration/Lesser)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Restoration, Lesser	OUTPUTNAME:Scroll (Restoration, Lesser)		TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
+Scroll (Restoration/Lesser)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Restoration (Lesser)	OUTPUTNAME:Scroll (Restoration, Lesser)		TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
 Scroll (Shatter/Divine)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Shatter	OUTPUTNAME:Scroll (Shatter)				TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
 Scroll (Shield Other)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Shield Other	TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
 Scroll (Silence/Divine)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=3|Silence	OUTPUTNAME:Scroll (Silence)				TYPE:Magic.Scroll.Divine.Consumable	COST:150	WT:0.01	SOURCEPAGE:p.237
@@ -1278,7 +1277,7 @@ Scroll (Magic Circle against Chaos/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL
 Scroll (Magic Circle against Evil/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Circle against Evil	OUTPUTNAME:Scroll (Magic Circle against Evil)	TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Magic Circle against Good/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Circle against Good	OUTPUTNAME:Scroll (Magic Circle against Good)	TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Magic Circle against Law/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Circle against Law	OUTPUTNAME:Scroll (Magic Circle against Law)	TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
-Scroll (Magic Fang/Greater)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Fang, Greater	OUTPUTNAME:Scroll (Magic Fang, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
+Scroll (Magic Fang/Greater)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Fang (Greater)	OUTPUTNAME:Scroll (Magic Fang, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Magic Vestment)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Magic Vestment	TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Meld into Stone)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Meld into Stone	TYPE:Magic.Scroll.Divine.Consumable	COST:375	WT:0.01	SOURCEPAGE:p.237
 Scroll (Neutralize Poison/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=5|Neutralize Poison	OUTPUTNAME:Scroll (Neutralize Poison)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Neutralize any existing poison and prevent any poison from affecting the drinker for % minutes (PH 257)|(CASTERLEVEL*10)	COST:375	WT:0.01	SOURCEPAGE:p.237
@@ -1323,9 +1322,9 @@ Scroll (Giant Vermin)																SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Gia
 Scroll (Holy Sword)																SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Holy Sword	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Imbue with Spell Ability)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Imbue with Spell Ability	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Inflict Critical Wounds)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Inflict Critical Wounds	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
-Scroll (Magic Weapon/Greater/Divine)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Magic Weapon, Greater	OUTPUTNAME:Scroll (Magic Weapon, Greater)	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
+Scroll (Magic Weapon/Greater/Divine)						SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Magic Weapon (Greater)	OUTPUTNAME:Scroll (Magic Weapon, Greater)	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Nondetection/Divine)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Nondetection	OUTPUTNAME:Scroll (Nondetection)		SPROP:Difficult to detect by divination spells for 5 hours (PH P.245)	TYPE:Magic.Scroll.Divine.Consumable	COST:750	WT:0.01	SOURCEPAGE:p.237
-Scroll (Planar Ally/Lesser)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Planar Ally, Lesser	OUTPUTNAME:Scroll (Planar Ally, Lesser)	TYPE:Magic.Scroll.Divine.Consumable	COST:1200	WT:0.01	SOURCEPAGE:p.237
+Scroll (Planar Ally/Lesser)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Planar Ally (Lesser)	OUTPUTNAME:Scroll (Planar Ally, Lesser)	TYPE:Magic.Scroll.Divine.Consumable	COST:1200	WT:0.01	SOURCEPAGE:p.237
 Scroll (Poison)																	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Poison	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Reincarnate)																SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Reincarnate	TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
 Scroll (Repel Vermin/Divine)								SPELLS:Magic Item|TIMES=1|CASTERLEVEL=7|Repel Vermin	OUTPUTNAME:Scroll (Repel Vermin)		TYPE:Magic.Scroll.Divine.Consumable	COST:700	WT:0.01	SOURCEPAGE:p.237
@@ -1347,11 +1346,11 @@ Scroll (Awaken)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Awaken	TYPE:
 Scroll (Baleful Polymorph/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Baleful Polymorph	OUTPUTNAME:Scroll (Baleful Polymorph)		TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Break Enchantment/Divine/Lvl 5)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Break Enchantment	OUTPUTNAME:Scroll (Break Enchantment)		TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Call Lightning Storm)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Call Lightning Storm	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
-Scroll (Command/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Command, Greater	OUTPUTNAME:Scroll (Command, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
+Scroll (Command/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Command (Greater)	OUTPUTNAME:Scroll (Command, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Commune)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Commune	TYPE:Magic.Scroll.Divine.Consumable	COST:1625	WT:0.01	SOURCEPAGE:p.237
 Scroll (Commune with Nature)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Commune with Nature	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Control Winds)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Control Winds	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cure Light Wounds/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Cure Light Wounds, Mass	OUTPUTNAME:Scroll (Cure Light Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 1d8+9 damage (PH P.215)	COST:1125	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cure Light Wounds/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Cure Light Wounds (Mass)	OUTPUTNAME:Scroll (Cure Light Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 1d8+9 damage (PH P.215)	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dispel Chaos)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dispel Chaos	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dispel Evil)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dispel Evil	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dispel Good)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dispel Good	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
@@ -1360,7 +1359,7 @@ Scroll (Disrupting Weapon)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Dis
 Scroll (Flame Strike)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Flame Strike	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Hallow)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Hallow	TYPE:Magic.Scroll.Divine.Consumable	COST:6125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Ice Storm/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Ice Storm	OUTPUTNAME:Scroll (Ice Storm)				TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
-Scroll (Inflict Light Wounds/Mass)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Inflict Light Wounds, Mass	OUTPUTNAME:Scroll (Inflict Light Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
+Scroll (Inflict Light Wounds/Mass)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Inflict Light Wounds (Mass)	OUTPUTNAME:Scroll (Inflict Light Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Insect Plague)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Insect Plague	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Mark of Justice)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Mark of Justice	TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
 Scroll (Plane Shift/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Plane Shift	OUTPUTNAME:Scroll (Plane Shift)			TYPE:Magic.Scroll.Divine.Consumable	COST:1125	WT:0.01	SOURCEPAGE:p.237
@@ -1387,27 +1386,27 @@ Scroll (Wall of Thorns)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=9|Wall 
 Scroll (Animate Objects/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Animate Objects	OUTPUTNAME:Scroll (Animate Objects)				TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Antilife Shell)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Antilife Shell	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Banishment/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Banishment	OUTPUTNAME:Scroll (Banishement)				TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Bear's Endurance/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bear's Endurance, Mass	OUTPUTNAME:Scroll (Bear's Endurance, Mass)		TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Bear's Endurance/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bear's Endurance (Mass)	OUTPUTNAME:Scroll (Bear's Endurance, Mass)		TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Blade Barrier)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Blade Barrier	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Bull's Strength/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bull's Strength, Mass	OUTPUTNAME:Scroll (Bull's Strength, Mass)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cat's Grace/Mass/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cat's Grace, Mass	OUTPUTNAME:Scroll (Cat's Grace, Mass)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Bull's Strength/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Bull's Strength (Mass)	OUTPUTNAME:Scroll (Bull's Strength, Mass)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cat's Grace/Mass/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cat's Grace (Mass)	OUTPUTNAME:Scroll (Cat's Grace, Mass)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Create Undead/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Create Undead	OUTPUTNAME:Scroll (Create Undead)				TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cure Moderate Wounds/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cure Moderate Wounds, Mass	OUTPUTNAME:Scroll (Cure Moderate Wounds, Mass)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 2d8 +11 damage (PH P.216)	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Dispel Magic/Greater/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Dispel Magic, Greater	OUTPUTNAME:Scroll (Dispel Magic, Greater/Divine)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Eagle's Splendor/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Eagle's Splendor, Mass	OUTPUTNAME:Scroll (Eagle's Splendor, Mass)		TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cure Moderate Wounds/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Cure Moderate Wounds (Mass)	OUTPUTNAME:Scroll (Cure Moderate Wounds, Mass)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 2d8 +11 damage (PH P.216)	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Dispel Magic/Greater/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Dispel Magic (Greater)	OUTPUTNAME:Scroll (Dispel Magic, Greater/Divine)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Eagle's Splendor/Mass/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Eagle's Splendor (Mass)	OUTPUTNAME:Scroll (Eagle's Splendor, Mass)		TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Find the Path/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Find the Path	OUTPUTNAME:Scroll (Find the Path)				TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Fire Seeds)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Fire Seeds	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Forbiddance)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Forbiddance	TYPE:Magic.Scroll.Divine.Consumable	COST:4650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Geas/Quest/Divine)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Geas/Quest	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Glyph of Warding/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Glyph of Warding, Greater	OUTPUTNAME:Scroll (Glyph of Warding, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Glyph of Warding/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Glyph of Warding (Greater)	OUTPUTNAME:Scroll (Glyph of Warding, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Harm)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Harm	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Heal)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Heal	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Heroes' Feast/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Heroes' Feast	OUTPUTNAME:Scroll (Heroes' Feast)				TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Inflict Moderate Wounds/Mass)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Inflict Moderate Wounds, Mass	OUTPUTNAME:Scroll (Inflict Moderate Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Inflict Moderate Wounds/Mass)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Inflict Moderate Wounds (Mass)	OUTPUTNAME:Scroll (Inflict Moderate Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Ironwood)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Ironwood	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Liveoak)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Liveoak	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Move Earth/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Move Earth	OUTPUTNAME:Scroll (Move Earth)				TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
-Scroll (Owl's Wisdom/Mass/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Owl's Wisdom, Mass	OUTPUTNAME:Scroll (Owl's Wisdom, Mass)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
+Scroll (Owl's Wisdom/Mass/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Owl's Wisdom (Mass)	OUTPUTNAME:Scroll (Owl's Wisdom, Mass)			TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Planar Ally)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Planar Ally	TYPE:Magic.Scroll.Divine.Consumable	COST:2400	WT:0.01	SOURCEPAGE:p.237
 Scroll (Repel Wood)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Repel Wood	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
 Scroll (Spellstaff)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=11|Spellstaff	TYPE:Magic.Scroll.Divine.Consumable	COST:1650	WT:0.01	SOURCEPAGE:p.237
@@ -1428,18 +1427,18 @@ Scroll (Blasphemy)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Blasphem
 Scroll (Changestaff)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Changestaff	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Control Weather/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Control Weather	OUTPUTNAME:Scroll (Control Weather)				TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Creeping Doom)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Creeping Doom	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cure Serious Wounds/Mass)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Cure Serious Wounds, Mass	OUTPUTNAME:Scroll (Cure Serious Wounds, Mass)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 3d8+13 damage (PH P.216)	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cure Serious Wounds/Mass)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Cure Serious Wounds (Mass)	OUTPUTNAME:Scroll (Cure Serious Wounds, Mass)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 3d8+13 damage (PH P.216)	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Destruction)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Destruction	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dictum)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Dictum	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Ethereal Jaunt/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Ethereal Jaunt	OUTPUTNAME:Scroll (Ethereal Jaunt)				TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Holy Word)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Holy Word	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Inflict Serious Wounds/Mass)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Inflict Serious Wounds, Mass	OUTPUTNAME:Scroll (Inflict Serious Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Inflict Serious Wounds/Mass)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Inflict Serious Wounds (Mass)	OUTPUTNAME:Scroll (Inflict Serious Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Refuge/Divine)				SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Refuge	OUTPUTNAME:Scroll (Refuge)					TYPE:Magic.Scroll.Divine.Consumable	COST:3775	WT:0.01	SOURCEPAGE:p.237
 Scroll (Regenerate/Lvl 7)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Regenerate	OUTPUTNAME:Scroll (Regenerate)				TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Repulsion/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Repulsion	OUTPUTNAME:Scroll (Repulsion)					TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Restoration/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Restoration, Greater	OUTPUTNAME:Scroll (Restoration, Greater)			TYPE:Magic.Scroll.Divine.Consumable	COST:4775	WT:0.01	SOURCEPAGE:p.237
+Scroll (Restoration/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Restoration (Greater)	OUTPUTNAME:Scroll (Restoration, Greater)			TYPE:Magic.Scroll.Divine.Consumable	COST:4775	WT:0.01	SOURCEPAGE:p.237
 Scroll (Resurrection)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Resurrection	TYPE:Magic.Scroll.Divine.Consumable	COST:12275	WT:0.01	SOURCEPAGE:p.237
-Scroll (Scrying/Greater/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Scrying, Greater	OUTPUTNAME:Scroll (Scrying, Greater)			TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
+Scroll (Scrying/Greater/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Scrying (Greater)	OUTPUTNAME:Scroll (Scrying, Greater)			TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Summon Monster VII/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Summon Monster VII	OUTPUTNAME:Scroll (Summon Monster VII)			TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Summon Nature's Ally VII)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Summon Nature's Ally VII	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
 Scroll (Sunbeam)														SPELLS:Magic Item|TIMES=1|CASTERLEVEL=13|Sunbeam	TYPE:Magic.Scroll.Divine.Consumable	COST:2275	WT:0.01	SOURCEPAGE:p.237
@@ -1455,19 +1454,19 @@ Scroll (Antimagic Field/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Antima
 Scroll (Cloak of Chaos)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Cloak of Chaos	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Control Plants)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Control Plants	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Create Greater Undead/Divine)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Create Greater Undead	OUTPUTNAME:Scroll (Create Greater Undead)			TYPE:Magic.Scroll.Divine.Consumable	COST:3600	WT:0.01	SOURCEPAGE:p.237
-Scroll (Cure Critical Wounds/Mass)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Cure Critical Wounds, Mass	OUTPUTNAME:Scroll (Cure Critical Wounds, Mass)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 4d8+15 damage (PH P.215)	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Cure Critical Wounds/Mass)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Cure Critical Wounds (Mass)	OUTPUTNAME:Scroll (Cure Critical Wounds, Mass)		TYPE:Magic.Scroll.Divine.Consumable	SPROP:Cures 4d8+15 damage (PH P.215)	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Dimensional Lock/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Dimensional Lock	OUTPUTNAME:Scroll (Dimensional Lock)			TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Discern Location/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Discern Location	OUTPUTNAME:Scroll (Discern Location)			TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Earthquake)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Earthquake	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Finger of Death/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Finger of Death	OUTPUTNAME:Scroll (Finger of Death)				TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Fire Storm)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Fire Storm	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Holy Aura)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Holy Aura	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
-Scroll (Inflict Critical Wounds/Mass)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Inflict Critical Wounds, Mass	OUTPUTNAME:Scroll (Inflict Critical Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
-Scroll (Planar Ally/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Planar Ally, Greater	OUTPUTNAME:Scroll (Planar Ally, Greater)			TYPE:Magic.Scroll.Divine.Consumable	COST:5500	WT:0.01	SOURCEPAGE:p.237
+Scroll (Inflict Critical Wounds/Mass)	SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Inflict Critical Wounds (Mass)	OUTPUTNAME:Scroll (Inflict Critical Wounds, Mass)	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Planar Ally/Greater)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Planar Ally (Greater)	OUTPUTNAME:Scroll (Planar Ally, Greater)			TYPE:Magic.Scroll.Divine.Consumable	COST:5500	WT:0.01	SOURCEPAGE:p.237
 Scroll (Repel Metal or Stone)												SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Repel Metal or Stone	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Reverse Gravity/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Reverse Gravity	OUTPUTNAME:Scroll (Reverse Gravity)				TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Shield of Law)													SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Shield of Law	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
-Scroll (Spell Immunity/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Spell Immunity, Greater	OUTPUTNAME:Scroll (Spell Immunity, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
+Scroll (Spell Immunity/Greater)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Spell Immunity (Greater)	OUTPUTNAME:Scroll (Spell Immunity, Greater)		TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Summon Monster VIII/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Summon Monster VIII	OUTPUTNAME:Scroll (Summon Monster VIII)			TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Summon Nature's Ally VIII)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Summon Nature's Ally VIII	TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
 Scroll (Sunburst/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=15|Sunburst	OUTPUTNAME:Scroll (Sunburst)					TYPE:Magic.Scroll.Divine.Consumable	COST:3000	WT:0.01	SOURCEPAGE:p.237
@@ -1485,7 +1484,7 @@ Scroll (Energy Drain/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Energy Dr
 Scroll (Etherealness/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Etherealness	OUTPUTNAME:Scroll (Etherealness)		TYPE:Magic.Scroll.Divine.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Foresight/Divine)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Foresight	OUTPUTNAME:Scroll (Foresight)			TYPE:Magic.Scroll.Divine.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Gate/Divine)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Gate	OUTPUTNAME:Scroll (Gate)			TYPE:Magic.Scroll.Divine.Consumable	COST:8825	WT:0.01	SOURCEPAGE:p.237
-Scroll (Heal/Mass)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Heal, Mass	OUTPUTNAME:Scroll (Heal, Mass)		TYPE:Magic.Scroll.Divine.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
+Scroll (Heal/Mass)			SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Heal (Mass)	OUTPUTNAME:Scroll (Heal, Mass)		TYPE:Magic.Scroll.Divine.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Implosion)										SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Implosion	TYPE:Magic.Scroll.Divine.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Miracle)											SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Miracle	TYPE:Magic.Scroll.Divine.Consumable	COST:28825	WT:0.01	SOURCEPAGE:p.237
 Scroll (Regenerate/Lvl 9)		SPELLS:Magic Item|TIMES=1|CASTERLEVEL=17|Regenerate	OUTPUTNAME:Scroll (Regenerate)		TYPE:Magic.Scroll.Divine.Consumable	COST:3825	WT:0.01	SOURCEPAGE:p.237


### PR DESCRIPTION
Fixed an issue where some scrolls used incorrect spell KEYs, leading to incorrect output in the magic items spelllist.

The problem was present in spells with the substrings ", Greater", ", Lesser", and ", Mass" in their names. Fixed by using the intended spell KEYs, e.g. "Teleport (Greater)".