### PR TITLE
Fix for incorrect Summoner Domain Spells

### DIFF
--- a/data/35e/wizards_of_the_coast/supplement/complete_divine/cd_spells.lst
+++ b/data/35e/wizards_of_the_coast/supplement/complete_divine/cd_spells.lst
@@ -360,9 +360,9 @@ Pass without Trace.MOD									CLASSES:Shugenja=1																															
 Permanent Image.MOD									CLASSES:Shugenja=6													DOMAINS:Creation=7																		DESCRIPTOR:Air Shugenja
 Persistent Image.MOD									CLASSES:Shugenja=5																																		DESCRIPTOR:Air Shugenja
 Phantasmal Killer.MOD																									DOMAINS:Dream=4|Madness=6
-Planar Ally.MOD																										DOMAINS:Summoner=4
-Planar Ally (Greater).MOD																								DOMAINS:Summoner=6
-Planar Ally (Lesser).MOD																								DOMAINS:Summoner=8
+Planar Ally.MOD																										DOMAINS:Summoner=6
+Planar Ally (Greater).MOD																								DOMAINS:Summoner=8
+Planar Ally (Lesser).MOD																								DOMAINS:Summoner=4
 Plant Growth.MOD										CLASSES:Shugenja=3																																		DESCRIPTOR:Earth Shugenja
 Poison.MOD											CLASSES:Blighter=3													DOMAINS:Pestilence=4
 Polar Ray.MOD																										DOMAINS:Cold=8


### PR DESCRIPTION
Fixed an issue where Planar Ally (Lesser/Normal/Greater) domain spells were granted at incorrect spell levels.