### PR TITLE
Updated KEY to prevent mismatch with GM Bonus Ability

### DIFF
--- a/data/35e/wizards_of_the_coast/supplement/book_of_vile_darkness/bv_abilities.lst
+++ b/data/35e/wizards_of_the_coast/supplement/book_of_vile_darkness/bv_abilities.lst
@@ -239,7 +239,7 @@ Demonic Wings	KEY:Black Magic Elixir ~ Demonic Wings			CATEGORY:Special Ability	
 
 ###Block
 Add Spellcaster (Any)		KEY:Add Spellcaster ~ Any	CATEGORY:Special Ability	ADD:SPELLCASTER|ANY						CHOOSE:NOCHOICE	MULT:YES	STACK:YES
-+1 Bonus Feat			KEY:+1 Bonus Feat			CATEGORY:Special Ability	TYPE:Bonus Feat		BONUS:ABILITYPOOL|FEAT|1	CHOOSE:NOCHOICE	MULT:YES	STACK:YES
++1 Bonus Feat			KEY:Thrall ~ +1 Bonus Feat			CATEGORY:Special Ability	TYPE:Bonus Feat		BONUS:ABILITYPOOL|FEAT|1	CHOOSE:NOCHOICE	MULT:YES	STACK:YES
 
 ###Block: Templates - Incomplete
 # Ability Name	Unique Key							Category of Ability		Type								Visible	Define				Description					Source Page

--- a/data/35e/wizards_of_the_coast/supplement/book_of_vile_darkness/bv_abilitycategories.lst
+++ b/data/35e/wizards_of_the_coast/supplement/book_of_vile_darkness/bv_abilitycategories.lst
@@ -30,8 +30,8 @@ ABILITYCATEGORY:Thrall of Orcus Bonus Feat					VISIBLE:QUALIFY	EDITABLE:YES	EDIT
 
 
 
-ABILITYCATEGORY:Thrall Of Demogorgon Ability	VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:Special Ability	ABILITYLIST:Add Spellcaster ~ Any|+1 Bonus Feat				PLURAL:Thrall Of Demogorgon Ability				DISPLAYLOCATION:Class Features
-ABILITYCATEGORY:Thrall Of Orcus Ability		VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:Special Ability	ABILITYLIST:Add Spellcaster ~ Any|+1 Bonus Feat					PLURAL:Thrall Of Orcus Ability				DISPLAYLOCATION:Class Features
+ABILITYCATEGORY:Thrall Of Demogorgon Ability	VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:Special Ability	ABILITYLIST:Add Spellcaster ~ Any|Thrall ~ +1 Bonus Feat				PLURAL:Thrall Of Demogorgon Ability				DISPLAYLOCATION:Class Features
+ABILITYCATEGORY:Thrall Of Orcus Ability		VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:Special Ability	ABILITYLIST:Add Spellcaster ~ Any|Thrall ~ +1 Bonus Feat					PLURAL:Thrall Of Orcus Ability				DISPLAYLOCATION:Class Features
 ABILITYCATEGORY:Thrall Of Orcus Deformity		VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:FEAT			ABILITYLIST:Deformity (obese)|Deformity (gaunt)			PLURAL:Thrall Of Orcus Deformity				DISPLAYLOCATION:Class Features
 ABILITYCATEGORY:Black Magic Elixir			VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:Special Ability	TYPE:Warrior of Darkness Black Magic Elixir					PLURAL:Black Magic Elixir					DISPLAYLOCATION:Class Features
 ABILITYCATEGORY:Black Magic Oil			VISIBLE:QUALIFY	EDITABLE:YES	EDITPOOL:NO						CATEGORY:Special Ability	TYPE:Warrior of Darkness Black Magic Oil					PLURAL:Black Magic Oil						DISPLAYLOCATION:Class Features


### PR DESCRIPTION
"+1 Bonus Feat" interfered with the GM Award of the same name from ph_abilities.lst. Extended the KEY by "Thrall ~ " and updated it in the associated ability pool.