### PR TITLE
Fix for #1173 - FFD20

### DIFF
--- a/data/pathfinder/homebrew/final_fantasy/pf_core/_pf_core.pcc
+++ b/data/pathfinder/homebrew/final_fantasy/pf_core/_pf_core.pcc
@@ -14,6 +14,7 @@ PUBNAMEWEB:http://www.finalfantasyd20.com/
 # Core
 ALIGNMENT:pf__align.lst
 DATACONTROL:pf__datacontrols.lst
+RACE:*/_universal/races.lst
 SAVE:pf__saves.lst
 SIZE:pf__sizes.lst
 STAT:pf__stats.lst


### PR DESCRIPTION
Vest solved this, loading this races.lst in the PCC fixes creating a character. This resolves #1173 on my end - using 6.08.00RC10 with 6.08 data. From my understanding, this lst contains the `<not selected>` option for races, which needs to be loaded with every system.