### PR TITLE
Improved location of Kingdom of Kalamar's Players Guide in the Sources window.

### DIFF
--- a/data/35e/kenzer_and_co/kalamar/players_guide/_players_guide.pcc
+++ b/data/35e/kenzer_and_co/kalamar/players_guide/_players_guide.pcc
@@ -4,7 +4,7 @@ GAMEMODE:35e|Bahamut35e
 GENRE:Fantasy
 BOOKTYPE:Supplement
 SETTING:Fantasy
-TYPE:Kenzer_and_Co.Campaign
+TYPE:Kenzer and Co.Campaign
 STATUS:ALPHA
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e
 PUBNAMELONG:Kenzer and Co


### PR DESCRIPTION
The Kingdom of Kalamar's Players Guide is put into a folder called "Kenzer_and_Co" (note the underscores), which:
1. doesn't look great;
2. puts it in a different folder than the Campaign Setting.

This fix removed the underscores.