### PR TITLE
Fixed alignment control causing errors.

### DIFF
--- a/system/gameModes/Bahamut35e/miscinfo.lst
+++ b/system/gameModes/Bahamut35e/miscinfo.lst
@@ -1,8 +1,17 @@
 # message displayed when experience added allows character to advance a level
 LEVELMSG:Congratulations, you can advance with that much experience!
 #
-ACNAME:Armor Class
+#
+ALIGNMENTNAME:Alignment
+HPNAME:Hit Points
+HPABBREV:HP
+#ALTHPNAME:
+#ALTHPABBREV:
 
+# AC tags can be used to display AC info by using appropriate name and abbrev.
+# ACNAME: and ACABBREV: are required for proper usage.
+ACNAME:Armor Class
+ACABBREV:AC
 
 # Stacking bonuses
 BONUSSTACKS:Defense.Dodge.Circumstance.NotRanged.NotFlatFooted

--- a/system/gameModes/Bahamut3e/miscinfo.lst
+++ b/system/gameModes/Bahamut3e/miscinfo.lst
@@ -3,8 +3,16 @@
 LEVELMSG:Congratulations, you can advance with that much experience!
 #
 #
+ALIGNMENTNAME:Alignment
+HPNAME:Hit Points
+HPABBREV:HP
+#ALTHPNAME:
+#ALTHPABBREV:
 
+# AC tags can be used to display AC info by using appropriate name and abbrev.
+# ACNAME: and ACABBREV: are required for proper usage.
 ACNAME:Armor Class
+ACABBREV:AC
 
 #
 #misc. currency specific items


### PR DESCRIPTION
In the Bahamut 3e and 35e gamemodes (I haven't checked any others), the Alignment-control doesn't work (at least in PCGen 6.08.00RC10). The log shows a NullPointerException when trying to retrieve the alignment. This is caused due to a missing "ALIGNMENTNAME" in the miscinfo.lst of the gamemode.

This fix adds the missing entry. I have added a few other entries that were in the PCGen original miscinfo.lst as well, just in case those are needed too.