### PR TITLE
Proper capitalization for the Duskblade classname for the Detect Magic spell.

### DIFF
--- a/data/35e/wizards_of_the_coast/supplement/players_handbook_2/ph2_spells.lst
+++ b/data/35e/wizards_of_the_coast/supplement/players_handbook_2/ph2_spells.lst
@@ -235,7 +235,7 @@ Time Stop.MOD				CLASSES:Beguiler=9
 ###Duskblade Spelllist
 Acid Splash.MOD				CLASSES:Duskblade=0
 Dancing Lights.MOD			CLASSES:Duskblade=0
-Detect Magic.MOD			CLASSES:DUskblade=0
+Detect Magic.MOD			CLASSES:Duskblade=0
 Disrupt Undead.MOD			CLASSES:Duskblade=0
 Flare.MOD				CLASSES:Duskblade=0
 Ghost Sound.MOD				CLASSES:Duskblade=0


### PR DESCRIPTION
A small capitalization typo fix for the Duskblade classname for the Detect Magic spell in the D&D 3.5e Player's Handbook 2.