### PR TITLE
Re-did D&D 3.x ranks to match latest standard.

### DIFF
--- a/data/35e/green_ronin/advanced_player_manual/_advanced_players_manual.pcc
+++ b/data/35e/green_ronin/advanced_player_manual/_advanced_players_manual.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Thu Jul 10 13:59:32 2014 -- reformated by prettylst.pl v1.51 (build 24365)
 CAMPAIGN:Advanced Player's Manual
-RANK:4
 GAMEMODE:35e|Bahamut35e
+RANK:200509
 PUBNAMELONG:Green Ronin
 PUBNAMESHORT:Ronin
 PUBNAMEWEB:http://www.greenronin.com
@@ -9,6 +9,7 @@ TYPE:Green Ronin Publishing.Supplement
 SOURCELONG:Advanced Player's Manual
 SOURCESHORT:APM
 SOURCEWEB:http://www.greenronin.com
+SOURCEDATE:2005-09
 ISOGL:YES
 ISLICENSED:NO
 

--- a/data/35e/green_ronin/hamunaptra/book_of_days/_book_of_days.pcc
+++ b/data/35e/green_ronin/hamunaptra/book_of_days/_book_of_days.pcc
@@ -2,7 +2,7 @@
 CAMPAIGN:Hamunaptra, The Book of Days
 KEY:Hamunaptra - The Book of Days
 GAMEMODE:35e|Bahamut35e
-RANK:6
+RANK:200501
 GENRE:Fantasy
 BOOKTYPE:Supplement
 SETTING:Hamunaptra
@@ -10,6 +10,7 @@ TYPE:Green Ronin Publishing.Hamunaptra
 SOURCELONG:Hamunaptra, The Book of Days
 SOURCESHORT:BoD
 SOURCEWEB:http://www.greenronin.com/
+SOURCEDATE:2005-01
 ISOGL:YES
 COPYRIGHT:Open Game License v 1.0 Copyright 2000, Wizards of the Coast, Inc.
 COPYRIGHT:System Reference Document Copyright 2000-2003, Wizards of the Coast, Inc.; Authors Jonathan Tweet, Monte Cook, Skip Williams, Rich Baker, Andy Collins, David Noonan, Rich Redman, Bruce R. Cordell, based on original material by E. Gary Gygax and Dave Arneson.

--- a/data/35e/green_ronin/the_psychics_handbook/_the_psychics_handbook.pcc
+++ b/data/35e/green_ronin/the_psychics_handbook/_the_psychics_handbook.pcc
@@ -3,7 +3,7 @@ CAMPAIGN:The Psychic's Handbook (35e)
 GAMEMODE:35e
 TYPE:Green Ronin.Supplement.Master Class
 BOOKTYPE:Supplement|PsychicCore
-RANK:6
+RANK:200509
 STATUS:BETA
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e
 PUBNAMELONG:Green Ronin Publishing
@@ -12,6 +12,7 @@ PUBNAMEWEB:http://www.greenronin.com
 SOURCELONG:The Psychic's Handbook
 SOURCESHORT:TPH
 SOURCEWEB:http://www.greenronin.com
+SOURCEDATE:2005-09
 ISOGL:YES
 COPYRIGHT:Open Game License v 1.0, Copyright 2000, Wizards of the Coast, Inc.
 

--- a/data/35e/homebrew/andy_collins/_andy_collins.pcc
+++ b/data/35e/homebrew/andy_collins/_andy_collins.pcc
@@ -1,7 +1,6 @@
-
 CAMPAIGN:Andy Collins Homebrew
 GAMEMODE:35e|Bahamut35e
-RANK:7
+RANK:200300
 TYPE:Andy Collins.Homebrew
 STATUS:ALPHA
 # SHOWINMENU:YES - Shows the Set in the basic loader
@@ -12,6 +11,7 @@ ISOGL:YES
 PUBNAMELONG:Andy Collins
 PUBNAMESHORT:AC
 PUBNAMEWEB:http://www.andycollins.net/Features/item_feats.htm
+SOURCEDATE:2003-00
 
 #COPYRIGHT:Wizards of the Coast is the copyright holder. This is a set derived from both the OGL and actual Book.
 

--- a/data/35e/homebrew/michael_tresca/krull/_krull.pcc
+++ b/data/35e/homebrew/michael_tresca/krull/_krull.pcc
@@ -2,17 +2,18 @@
 # CVS $Revision$ $Author$ -- Sat Jan  4 10:42:33 2014 -- reformated by prettylst.pl v1.50 (build 22746)
 CAMPAIGN:Krull (35e conversion)
 GAMEMODE:35e|Bahamut35e
-RANK:7
+RANK:200203
 TYPE:Michael Tresca.Homebrew
 STATUS:ALPHA
 # SHOWINMENU:YES - Shows the Set in the basic loader
 #SHOWINMENU:YES
+SOURCEDATE:2002-03
 BOOKTYPE:Homebrew
 ISLICENSED:NO
 ISOGL:YES
 PUBNAMELONG:Michael Tresca
 PUBNAMESHORT:MT
-#PUBNAMEWEB:http://www.wizards.com/default.asp?x=dnd
+PUBNAMEWEB:http://www.retromud.org/talien
 
 #COPYRIGHT:Wizards of the Coast is the copyright holder. This is a set derived from both the OGL and actual Book.
 

--- a/data/35e/homebrew/rich_burlew/_rich_burlew_homebrew.pcc
+++ b/data/35e/homebrew/rich_burlew/_rich_burlew_homebrew.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sat Jan  4 10:42:33 2014 -- reformated by prettylst.pl v1.50 (build 22746)
 CAMPAIGN:Rich Burlew Homebrew
 GAMEMODE:35e|Bahamut35e
-RANK:7
+RANK:201010
 TYPE:Rich Burlew.Homebrew
 STATUS:ALPHA
 BOOKTYPE:Homebrew
@@ -9,7 +9,7 @@ ISLICENSED:NO
 ISOGL:YES
 PUBNAMELONG:Rich Burlew
 PUBNAMESHORT:RB
-#PUBNAMEWEB:http://www.wizards.com/default.asp?x=dnd
+#PUBNAMEWEB:https://forums.giantitp.com/showthread.php?172910-Articles-Previously-Appearing-on-GiantITP-com
 
 #COPYRIGHT:Wizards of the Coast is the copyright holder. This is a set derived from both the OGL and actual Book.
 

--- a/data/35e/kenzer_and_co/_kingdoms_of_kalamar_campaign.pcc
+++ b/data/35e/kenzer_and_co/_kingdoms_of_kalamar_campaign.pcc
@@ -3,7 +3,7 @@ KEY:Kingdoms of Kalamar v.3.5
 BOOKTYPE:Campaign Setting
 GAMEMODE:Bahamut35e
 SOURCELONG:Kingdoms of Kalamar Campaign
-SOURCESHORT:PH
+#SOURCESHORT:PH
 SOURCEDATE:2003-03
 RANK:200303
 PUBNAMELONG:Kenzer and Co

--- a/data/35e/mongoose_publishing/ultimate_prestige_classes_vol_1/_ultimate_prestige_classes_vol_1.pcc
+++ b/data/35e/mongoose_publishing/ultimate_prestige_classes_vol_1/_ultimate_prestige_classes_vol_1.pcc
@@ -1,7 +1,7 @@
 CAMPAIGN:Ultimate Prestige Classes, Vol 1
 KEY:Ultimate Prestige Classes Vol 1
-RANK:4
 GAMEMODE:35e|Bahamut35e
+RANK:200200
 PUBNAMELONG:Mongoose Publishing
 PUBNAMESHORT:MP
 PUBNAMEWEB:http://www.mongoosepublishing.com
@@ -9,6 +9,7 @@ TYPE:Mongoose Publishing.Supplement
 SOURCELONG:Ultimate Prestige Classes, Vol 1
 SOURCESHORT:UPC1
 SOURCEWEB:http://www.mongoosepublishing.com
+SOURCEDATE:2002
 ISOGL:YES
 ISLICENSED:NO
 

--- a/data/35e/paizo/dragon_magazine/dragon_magazine.pcc
+++ b/data/35e/paizo/dragon_magazine/dragon_magazine.pcc
@@ -1,7 +1,7 @@
 CAMPAIGN:Dragon Magazine
 GAMEMODE:35e|Bahamut35e
 TYPE:Paizo.Supplement
-RANK:6
+
 GENRE:Fantasy
 BOOKTYPE:Supplement
 SETTING:Fantasy
@@ -18,7 +18,7 @@ INFOTEXT:Information from the multiple Dragon Magazine issues
 
 PCC:311/dm311.pcc
 PCC:313/dm313.pcc
-PCC:335/dm335.pcc
+PCC:335/_dm335.pcc
 PCC:336/dm336.pcc
 PCC:338/dm338.pcc
 PCC:358/dm358.pcc

--- a/data/35e/valar_project/book_of_erotic_fantasy/_book_of_erotic_fantasy.pcc
+++ b/data/35e/valar_project/book_of_erotic_fantasy/_book_of_erotic_fantasy.pcc
@@ -4,13 +4,14 @@ GAMEMODE:35e
 TYPE:Valar Project.Accessory
 STATUS:ALPHA
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e
-RANK:3
+RANK:200311
 PUBNAMELONG:Valar Project, Inc.
 PUBNAMESHORT:Valar
 PUBNAMEWEB:http://www.valarproject.com/
 SOURCELONG:Book of Erotic Fantasy
 SOURCESHORT:BoEF
 SOURCEWEB:http://www.bookoferoticfantasy.com/
+SOURCEDATE:2003-11
 BOOKTYPE:Accessory
 GENRE:Fantasy
 SETTING:Generic

--- a/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/dragons_of_faerun/we_city_of_wyrmshadows/_we_city_of_wyrmshadows.pcc
+++ b/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/dragons_of_faerun/we_city_of_wyrmshadows/_we_city_of_wyrmshadows.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sun Dec  8 22:17:49 2013 -- reformated by prettylst.pl v1.50 (build 22352)
 CAMPAIGN:Dragons of Faerun - Web Enhancement - City of Wyrmshadows
-RANK:4
 GAMEMODE:35e|Bahamut35e
+RANK:200704
 GENRE:Fantasy
 BOOKTYPE:Sourcebook
 SETTING:Forgotten Realms
@@ -11,6 +11,7 @@ TYPE:Wizards of the Coast.Campaign Setting.Forgotten Realms
 PUBNAMELONG:Wizards of the Coast
 PUBNAMESHORT:WotC
 PUBNAMEWEB:http://www.wizards.com/default.asp?x=dnd
+SOURCEDATE:2007-04
 ISOGL:NO
 
 ABILITY:abilities.lst

--- a/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/players_guide_to_faerun/_players_guide_to_faerun.pcc
+++ b/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/players_guide_to_faerun/_players_guide_to_faerun.pcc
@@ -26,7 +26,7 @@ COVER:../../../../../_artwork/cover_35e_wotc_pg.jpg
 # LOGO should be logo_pub.file
 LOGO:../../../../../_artwork/logo_wotc.png
 
-# NOTE - where appropriate (spells & equip) have seperate files for each of the appropriate source books
+# NOTE - where appropriate (spells & equip) have separate files for each of the appropriate source books
 
 ###Block: Forgotten Realms Campaign Setting Specific Materials not updated by PG
 PCC:frcs/_frcs.pcc

--- a/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/shining_south/_shining_south.pcc
+++ b/data/35e/wizards_of_the_coast/campaign_settings/forgotten_realms/shining_south/_shining_south.pcc
@@ -28,7 +28,7 @@ LOGO:../../../../../_artwork/logo_wotc.png
 #Shining South
 #
 
-# NOTE - where appropriate (spells & equip) have seperate files for each of the appropriate source books
+# NOTE - where appropriate (spells & equip) have separate files for each of the appropriate source books
 ABILITY:shs_abilities.lst
 #ABILITYCATEGORY:shs_abilitycategories.lst
 CLASS:shs_classes.lst

--- a/data/35e/wizards_of_the_coast/campaign_settings/ghostwalk/_ghostwalk.pcc
+++ b/data/35e/wizards_of_the_coast/campaign_settings/ghostwalk/_ghostwalk.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sun Jul 19 13:55:40 2015 -- reformated by PCGen PrettyLST v6.05.01
 CAMPAIGN:Ghostwalk (35e conversion)
 KEY:35e ~ Ghostwalk
-RANK:3
+RANK:200306
 GAMEMODE:35e|Bahamut35e
 GENRE:Fantasy
 BOOKTYPE:Campaign Setting|CampaignCore
@@ -15,6 +15,7 @@ TYPE:Wizards of the Coast.Campaign Setting.Campaign Setting
 SOURCELONG:Ghostwalk
 SOURCESHORT:GW
 SOURCEWEB:http://www.wizards.com/
+SOURCEDATE:2003-06
 ISOGL:NO
 STATUS:BETA
 

--- a/data/35e/wizards_of_the_coast/supplement/dungeonscape/_dungeonscape.pcc
+++ b/data/35e/wizards_of_the_coast/supplement/dungeonscape/_dungeonscape.pcc
@@ -1,7 +1,7 @@
 # CVS $Revision$ $Author$ -- Sun Sep  7 00:28:24 2014 -- reformated by prettylst.pl v1.51 (build 24947)
 CAMPAIGN:Dungeonscape
-RANK:3
 GAMEMODE:35e|Bahamut35e
+RANK:200702
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e
 PRECAMPAIGN:1,INCLUDES=Tome of Magic
 GENRE:Fantasy
@@ -15,6 +15,7 @@ PUBNAMEWEB:www.wizards.com
 SOURCELONG:Dungeonscape
 SOURCESHORT:Du
 SOURCEWEB:www.wizards.com
+SOURCEDATE:2007-02
 ISOGL:NO
 ISLICENSED:NO
 COPYRIGHT:Wizards of the Coast

--- a/data/35e/wizards_of_the_coast/supplement/monster_manual_4/monster_manual_4.pcc
+++ b/data/35e/wizards_of_the_coast/supplement/monster_manual_4/monster_manual_4.pcc
@@ -1,6 +1,6 @@
 CAMPAIGN:Monster Manual IV
 GAMEMODE:35e|Bahamut35e
-RANK:2
+RANK:200607
 TYPE:Wizards of the Coast.Supplement
 PRECAMPAIGN:1,BOOKTYPE=Core Rules
 STATUS:BETA
@@ -12,6 +12,7 @@ PUBNAMESHORT:WotC
 PUBNAMEWEB:http://www.wizards.com/dnd
 SOURCELONG:Monster Manual IV
 SOURCESHORT:MM4
+SOURCEDATE:2006-07
 ISOGL:NO
 COPYRIGHT:Open Game License v 1.0a Copyright 2000, Wizards of the Coast, Inc.
 COPYRIGHT:Monster Manual IV Copyright, Wizards of the Coast, Inc.

--- a/data/35e/wizards_of_the_coast/web/factotums_and_spellthieves/_factotums_and_spellthieves.pcc
+++ b/data/35e/wizards_of_the_coast/web/factotums_and_spellthieves/_factotums_and_spellthieves.pcc
@@ -1,11 +1,13 @@
 CAMPAIGN:Factotums and Spellthieves
 #GAMEMODE:3e|35e|Bahamut35e #TODO
+RANK:200706
 TYPE:Wizards of the Coast.Web Enhancements
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e,INCLUDESBOOKTYPE=Core3e
 #,INCLUDES=Player's Guide to Faerun
 GENRE:Fantasy
 SETTING:Forgotten Realms
 SOURCEWEB:http://www.wizards.com/default.asp?x=dnd/frcc/20070606
+SOURCEDATE:2007-06
 PUBNAMELONG:Wizards of the Coast
 PUBNAMESHORT:WotC
 PUBNAMEWEB:http://www.wizards.com/dnd

--- a/data/35e/wizards_of_the_coast/web/fey_feature/_fey_feature.pcc
+++ b/data/35e/wizards_of_the_coast/web/fey_feature/_fey_feature.pcc
@@ -6,10 +6,11 @@ TYPE:Wizards of the Coast.Web Feature
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e,INCLUDESBOOKTYPE=Core3e
 PRECAMPAIGN:1,INCLUDES=Spell Compendium
 
-RANK:9
+RANK:200309
 SOURCELONG:Fey Feature
 SOURCESHORT:FF
 SOURCEWEB:https://www.wizards.com/default.asp?x=dnd/fey/20030905a
+SOURCEDATE:2003-09
 PUBNAMELONG:Wizards of the Coast
 PUBNAMESHORT:WotC
 PUBNAMEWEB:http://www.wizards.com/dnd

--- a/data/35e/wizards_of_the_coast/web/spellbook_archive/_spellbook_archive.pcc
+++ b/data/35e/wizards_of_the_coast/web/spellbook_archive/_spellbook_archive.pcc
@@ -4,10 +4,11 @@ KEY:Spellbook Archive
 GAMEMODE:3e|35e|Bahamut35e
 TYPE:Wizards of the Coast.Web Enhancements
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e,INCLUDESBOOKTYPE=Core3e
-RANK:9
+RANK:200305
 SOURCELONG:Spellbook Archive
 SOURCESHORT:SA
 SOURCEWEB:http://www.wizards.com/dnd/article.asp?x=dnd/sb/sb20030504x
+SOURCEDATE:2003-05
 PUBNAMELONG:Wizards of the Coast
 PUBNAMESHORT:WotC
 PUBNAMEWEB:http://www.wizards.com/dnd

--- a/data/35e/wizards_of_the_coast/web/swiftblade/_swiftblade.pcc
+++ b/data/35e/wizards_of_the_coast/web/swiftblade/_swiftblade.pcc
@@ -4,10 +4,11 @@ KEY:Swiftblade
 GAMEMODE:35e|Bahamut35e
 TYPE:Wizards of the Coast.Web Enhancements
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e
-RANK:3
+RANK:200703
 SOURCELONG:Swiftblade
 SOURCESHORT:SwBl
 SOURCEWEB:http://archive.wizards.com/default.asp?x=dnd/prc/20070327
+SOURCEDATE:2007-03
 PUBNAMELONG:Wizards of the Coast
 PUBNAMESHORT:WotC
 PUBNAMEWEB:http://www.wizards.com/dnd

--- a/data/35e/wizards_of_the_coast/web/the_minds_eye/_the_minds_eye.pcc
+++ b/data/35e/wizards_of_the_coast/web/the_minds_eye/_the_minds_eye.pcc
@@ -5,7 +5,7 @@ GAMEMODE:35e|Bahamut35e
 TYPE:Wizards of the Coast.Web Enhancements
 PRECAMPAIGN:1,INCLUDESBOOKTYPE=Core35e
 PRECAMPAIGN:1,INCLUDES=Expanded Psionics Handbook
-RANK:9
+RANK:200707
 SOURCELONG:The Mind's Eye
 SOURCESHORT:TME
 SOURCEWEB:http://www.wizards.com/default.asp?x=dnd/arch/psi

--- a/data/3e/green_ronin/armies_of_the_abyss/_armies_of_the_abyss.pcc
+++ b/data/3e/green_ronin/armies_of_the_abyss/_armies_of_the_abyss.pcc
@@ -3,10 +3,11 @@ KEY:Armies of the Abyss
 GAMEMODE:3e
 GENRE:Fantasy
 TYPE:Green Ronin Publishing.Supplement
-RANK:6
+RANK:200202
 SOURCELONG:Armies of the Abyss
 SOURCESHORT:AotA
 SOURCEWEB:http://www.greenronin.com
+SOURCEDATE:2002-02
 
 CLASS:aota_classes.lst
 DEITY:aota_deities.lst

--- a/data/3e/homebrew/michael_tresca/krull/_krull.pcc
+++ b/data/3e/homebrew/michael_tresca/krull/_krull.pcc
@@ -2,11 +2,12 @@
 # CVS $Revision$ $Author$ -- Sat Jan  4 10:42:33 2014 -- reformated by prettylst.pl v1.50 (build 22746)
 CAMPAIGN:Krull
 GAMEMODE:3e|Bahamut3e
-RANK:7
+RANK:200203
 TYPE:Michael Tresca.Homebrew
 STATUS:ALPHA
 # SHOWINMENU:YES - Shows the Set in the basic loader
 #SHOWINMENU:YES
+SOURCEDATE:2002-03
 BOOKTYPE:Homebrew
 ISLICENSED:NO
 ISOGL:YES


### PR DESCRIPTION
Re-did all the rank-entries in the D&D 3.x PPC's, following the latest standard (in other words, this is a fixed version of pull request 1271). Also includes some small meta-data additions I encountered while doing that.